### PR TITLE
updated pagination.py

### DIFF
--- a/DiscordUtils/Pagination.py
+++ b/DiscordUtils/Pagination.py
@@ -57,8 +57,11 @@ class AutoEmbedPaginator(object):
             elif str(reaction.emoji) == self.control_emojis[2]:
                 self.current_page = 0
                 for reaction in msg.reactions:
-                    if reaction.message.author.id == self.bot.user.id:
-                        await msg.remove_reaction(str(reaction.emoji), reaction.message.author)
+                    try:
+                        if reaction.message.author.id == self.bot.user.id:
+                            await msg.remove_reaction(str(reaction.emoji), reaction.message.author)
+                    except:
+                        pass
                 return msg
                 break
             elif str(reaction.emoji) == self.control_emojis[3]:


### PR DESCRIPTION
If the embed was deleted before the reaction were removed then it would throw a unknown message error. 
added a simple try catch to mitigate the issue