### PR TITLE
Made voice support optional

### DIFF
--- a/DiscordUtils/Music.py
+++ b/DiscordUtils/Music.py
@@ -119,18 +119,20 @@ def check_queue(ctx, opts, music, after, on_play, loop):
             loop.create_task(on_play(ctx, song))
 
 class Music(object):
-    if not has_voice:
-        raise RuntimeError("DiscordUtils[voice] install needed in order to use voice")
-
     def __init__(self):
+        if not has_voice:
+            raise RuntimeError("DiscordUtils[voice] install needed in order to use voice")
+
         self.queue = {}
         self.players = []
+
     def create_player(self, ctx, **kwargs):
         if not ctx.voice_client:
             raise NotConnectedToVoice("Cannot create the player because bot is not connected to voice")
         player = MusicPlayer(ctx, self, **kwargs)
         self.players.append(player)
         return player
+        
     def get_player(self, **kwargs):
         guild = kwargs.get("guild_id")
         channel = kwargs.get("channel_id")

--- a/DiscordUtils/Music.py
+++ b/DiscordUtils/Music.py
@@ -6,7 +6,7 @@ try:
     import discord
     has_voice = True
 except ImportError:
-    has_voice - False
+    has_voice = False
 
 if has_voice:
     youtube_dl.utils.bug_reports_message = lambda: ''

--- a/DiscordUtils/Music.py
+++ b/DiscordUtils/Music.py
@@ -1,11 +1,16 @@
-import youtube_dl
 import asyncio
-import discord
 import aiohttp
 import re
+try:
+    import youtube_dl
+    import discord
+    has_voice = True
+except ImportError:
+    has_voice - False
 
-youtube_dl.utils.bug_reports_message = lambda: ''
-ydl = youtube_dl.YoutubeDL({"format": "bestaudio/best", "restrictfilenames": True, "noplaylist": True, "nocheckcertificate": True, "ignoreerrors": True, "logtostderr": False, "quiet": True, "no_warnings": True, "source_address": "0.0.0.0"})
+if has_voice:
+    youtube_dl.utils.bug_reports_message = lambda: ''
+    ydl = youtube_dl.YoutubeDL({"format": "bestaudio/best", "restrictfilenames": True, "noplaylist": True, "nocheckcertificate": True, "ignoreerrors": True, "logtostderr": False, "quiet": True, "no_warnings": True, "source_address": "0.0.0.0"})
 
 class EmptyQueue(Exception):
     """Cannot skip because queue is empty"""
@@ -33,6 +38,9 @@ async def ytbettersearch(query):
     return url
 
 async def get_video_data(url, search, bettersearch, loop):
+    if not has_voice:
+        raise RuntimeError("DiscordUtils[voice] install needed in order to use voice")
+
     if not search and not bettersearch:
         data = await loop.run_in_executor(None, lambda: ydl.extract_info(url, download=False))
         source = data["url"]
@@ -85,6 +93,9 @@ async def get_video_data(url, search, bettersearch, loop):
             return Song(source, url, title, description, views, duration, thumbnail, channel, channel_url, False)
         
 def check_queue(ctx, opts, music, after, on_play, loop):
+    if not has_voice:
+        raise RuntimeError("DiscordUtils[voice] install needed in order to use voice")
+
     try:
         song = music.queue[ctx.guild.id][0]
     except IndexError:
@@ -108,6 +119,9 @@ def check_queue(ctx, opts, music, after, on_play, loop):
             loop.create_task(on_play(ctx, song))
 
 class Music(object):
+    if not has_voice:
+        raise RuntimeError("DiscordUtils[voice] install needed in order to use voice")
+
     def __init__(self):
         self.queue = {}
         self.players = []
@@ -132,6 +146,9 @@ class Music(object):
 
 class MusicPlayer(object):
     def __init__(self, ctx, music, **kwargs):
+        if not has_voice:
+            raise RuntimeError("DiscordUtils[voice] install needed in order to use voice")
+
         self.ctx = ctx
         self.voice = ctx.voice_client
         self.loop = ctx.bot.loop

--- a/README.md
+++ b/README.md
@@ -2,7 +2,16 @@
 DiscordUtils is a very useful library made to be used with [discord.py](https://pypi.org/project/discord.py/)
 
 # Installation
-`pip install DiscordUtils`
+For access to Pagination and InviteTracker use:
+```
+pip install DiscordUtils
+```
+
+or, instead use the following for access to Music functions aswell
+```
+pip install DiscordUtils[voice]
+```
+Requires discord.py[voice] so make sure you have all dependencies of it installed.
 
 # Example code
 

--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,6 @@ setuptools.setup(
     ],
     python_requires='>= 3.6',
     include_package_data=True,
-    install_requires=["discord.py[voice]", "youtube-dl"]
+    install_requires=["discord.py"],
+    extras_require={'voice': ["discord.py[voice]", "youtube-dl"]}
 )


### PR DESCRIPTION
⚠**Breaking Change**⚠

I've changed voice support to require installation with `pip install DiscordUtils[voice]`. This should enable people who only want to use paginate or invite tracking to not need to install discord.py[voice] or its dependencies.

~~I have not been able to test locally. but it should be ok 🤞~~ tested, works
I have also not updated the version number, I'll leave that to you

close #24 